### PR TITLE
Update prof pref timestamp endpoint to include year param

### DIFF
--- a/api/dbconn.py
+++ b/api/dbconn.py
@@ -134,7 +134,15 @@ class DBConn:
         from sql's 1s and 0s to json true and false."""
         conn = self.get_conn()
         cursor = conn.cursor(dictionary=True)
-        cursor.execute(sql)
+        try:
+            cursor.execute(sql)
+        except mysql.connector.Error as errmsg:
+            errmsg = f'Failed to execute query\
+                        \n{sql}\
+                        \nError: {errmsg}\n'
+            cursor.close()
+            return errmsg
+
         results = cursor.fetchall()
         conn.close()
 

--- a/docs/openapi/bundled.yaml
+++ b/docs/openapi/bundled.yaml
@@ -122,6 +122,30 @@ paths:
                 example: Deleted prof with id 78c74a60-281c-45f4-9536-7d128701ddb5
         '404':
           description: professor not found
+  /professors/preferences/times/{year}:
+    get:
+      tags:
+        - Professors
+      summary: GET /professors/preferences/times/{year}
+      description: Gets a list of all professor preference entries for the year
+      operationId: getProfessorPreferenceTimes
+      parameters:
+        - name: year
+          in: path
+          description: the year to get the list of preference entries for
+          required: true
+          schema:
+            type: integer
+            format: positive 4 digits
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArrayProfessorPreferenceTimes'
+        '404':
+          description: No entries exist for the year
   /professors/{id}/preferences:
     get:
       tags:
@@ -696,6 +720,46 @@ components:
           enum:
             - CSC
             - ECE
+    ProfessorPreferenceTimes:
+      type: object
+      required:
+        - prof_id
+        - first_name
+        - last_name
+        - time_stamp
+      properties:
+        prof_id:
+          description: uuid of professor
+          type: string
+          example: 61587323-6632-4dcf-bae8-2a51ed8585a0
+        first_name:
+          description: professor's first name
+          type: string
+          example: Bill
+        last_name:
+          description: professor's last name
+          type: string
+          example: Bird
+        time_stamp:
+          description: Time of preference entry
+          type: string
+          pattern: >-
+            ^([0-9]{2,4})-([0-1][0-9])-([0-3][0-9])(?:(
+            [0-2][0-9]):([0-5][0-9]):([0-5][0-9]))?$
+          example: '2022-06-21 09:30:26'
+    ArrayProfessorPreferenceTimes:
+      type: array
+      items:
+        $ref: '#/components/schemas/ProfessorPreferenceTimes'
+      example:
+        - prof_id: 61587323-6632-4dcf-bae8-2a51ed8585a0
+          first_name: Rich
+          last_name: Little
+          time_stamp: '2022-06-25 10:34:06'
+        - prof_id: 61587323-6632-4dcf-bae8-2a51ed8585a0
+          first_name: Dan
+          last_name: Mai
+          time_stamp: '2022-06-21 09:30:26'
     PreferredTime:
       type: object
       required:

--- a/docs/openapi/components/schemas/ArrayProfessorPreferenceTimes.yaml
+++ b/docs/openapi/components/schemas/ArrayProfessorPreferenceTimes.yaml
@@ -1,0 +1,17 @@
+type: array
+items:
+  $ref: 'ProfessorPreferenceTimes.yaml'
+example: [
+  {
+    "prof_id": "61587323-6632-4dcf-bae8-2a51ed8585a0",
+    "first_name": "Rich",
+    "last_name": "Little",
+    "time_stamp": "2022-06-25 10:34:06"
+  },
+  {
+    "prof_id": "61587323-6632-4dcf-bae8-2a51ed8585a0",
+    "first_name": "Dan",
+    "last_name": "Mai",
+    "time_stamp": "2022-06-21 09:30:26"
+  }
+]

--- a/docs/openapi/components/schemas/ProfessorPreferenceTimes.yaml
+++ b/docs/openapi/components/schemas/ProfessorPreferenceTimes.yaml
@@ -1,0 +1,24 @@
+type: object
+required:
+  - prof_id
+  - first_name
+  - last_name
+  - time_stamp
+properties:
+  prof_id:
+    description: uuid of professor
+    type: string
+    example: 61587323-6632-4dcf-bae8-2a51ed8585a0
+  first_name:
+    description: professor's first name
+    type: string
+    example: Bill
+  last_name:
+    description: professor's last name
+    type: string
+    example: Bird
+  time_stamp:
+    description: Time of preference entry
+    type: string
+    pattern: "^([0-9]{2,4})-([0-1][0-9])-([0-3][0-9])(?:( [0-2][0-9]):([0-5][0-9]):([0-5][0-9]))?$"
+    example: '2022-06-21 09:30:26'

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -38,6 +38,8 @@ paths:
     $ref: paths/professors/professors.yaml
   /professors/{id}:
     $ref: paths/professors/professors_{id}.yaml
+  /professors/preferences/times/{year}:
+    $ref: paths/professors/professors_preferences_times.yaml
   /professors/{id}/preferences:
     $ref: paths/professors/professors_{id}_preferences.yaml
   /courses:

--- a/docs/openapi/paths/professors/professors_preferences_times.yaml
+++ b/docs/openapi/paths/professors/professors_preferences_times.yaml
@@ -1,0 +1,25 @@
+get:
+  tags:
+    - Professors
+  summary: GET /professors/preferences/times/{year}
+  description: Gets a list of all professor preference entries for the year
+  operationId: getProfessorPreferenceTimes
+  parameters:
+    - name: year
+      in: path
+      description: the year of the preference entries
+      required: true
+      schema:
+        type: integer
+        format: positive 4 digits
+  responses:
+    '200':
+      description: successful operation
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/ArrayProfessorPreferenceTimes.yaml
+    '404':
+      description: No entries exist for the year
+    '400':
+      description: Bad sql query or invalid input parameter


### PR DESCRIPTION
# Description
Update the /professors/preferences/times/ endpoint  to query by year and add the endpoint to redocly (I originally forgot to add the new endpoint to redocly in my first PR for this issue).

- [x] Add prof pref timestamp endpoint to redocly
- [x] Add support to query by year

Fixes # (#71 )
## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] Ran Redocly locally to confirm the endpoint spec is added in doc
- [x] Use Zoe's script to prepopulate db with preferences and test the endpoint with valid, invalid, and empty queries
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have linted my code and fixed all issues
